### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
-#Generics
+# Generics
 
 
 ![Rick Rolled](http://i.imgur.com/no3t9ib.gif)
 
 High Quality video -> https://www.youtube.com/watch?v=dQw4w9WgXcQ
 
-##Note: This was a joke made for Gophercon2015. Sorry if you came here looking for something useful.
+## Note: This was a joke made for Gophercon2015. Sorry if you came here looking for something useful.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
